### PR TITLE
Optional App Named Folders

### DIFF
--- a/main.py
+++ b/main.py
@@ -308,7 +308,15 @@ class Plugin:
                         videoPipeline = f'pipewiresrc target-object=gamescope do-timestamp=true ! queue ! videoconvert ! queue ! vaapih264enc ! h264parse ! splitmuxsink name=sink muxer={muxer} muxer-pad-map=x-pad-map,audio=vid location={self._filepath} max-size-time=1000000000 max-files=480'
                 else:
                     logger.info("Setting local filepath no rolling")
-                    directory = Path(f"{self._localFilePath}/{app_name}")
+                    if self._app_named_directories:
+                        logger.debug("Setting local filepath for rolling recording (app-named directories)")
+
+                        directory = pathlib.Path(f"{self._localFilePath}/{app_name}")
+                        logger.debug(f"Directory (App Name): {directory}")
+                    else:
+                        directory = pathlib.Path(f"{self._localFilePath}")
+                        logger.debug(f"Directory (No App Name): {directory}")
+
                     logger.debug(f"Creating directory if not exists: {directory.__fspath__()}")
                     directory.mkdir(exist_ok=True)
 
@@ -602,6 +610,19 @@ class Plugin:
         logger.info("Current local file format: " + self._fileformat)
         return self._fileformat
 
+    async def enable_app_named_directories(self):
+        logger.info(f"App named directories: ON")
+        self._app_named_directories = True
+        await Plugin.saveConfig(self)
+
+    async def disable_app_named_directories(self):
+        logger.info(f"App named directories: OFF")
+        self._app_named_directories = False
+        await Plugin.saveConfig(self)
+
+    async def get_app_named_directories(self):
+        return self._app_named_directories
+
     async def loadConfig(self):
         logger.info("Loading settings from: {}".format(os.path.join(settingsDir, "decky-loader-settings.json")))
         ### TODO: IMPLEMENT ###
@@ -616,6 +637,7 @@ class Plugin:
         self._micEnabled = self._settings.getSetting("mic_enabled", False)
         self._micGain = self._settings.getSetting("mic_gain", 13.0)
         self._noiseReductionPercent = self._settings.getSetting("noise_reduction_percent", 50.0)
+        self._app_named_directories = self._settings.getSetting("app_named_directories", False)
 
         # Need this for initialization only honestly
         await Plugin.saveConfig(self)
@@ -688,7 +710,12 @@ class Plugin:
                     ff.write(f"file {str(f)}\n")
 
             dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-            rolling_directory = Path(f"{self._localFilePath}/{app_name}")
+
+            if self._app_named_directories:
+                rolling_directory = Path(f"{self._localFilePath}/{app_name}")
+            else:
+                rolling_directory = Path(f"{self._localFilePath}")
+
             logger.debug(f"Creating directory if not exists: {rolling_directory.__fspath__()}")
             rolling_directory.mkdir(exist_ok=True)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -73,6 +73,14 @@ class DeckyRecorderLogic
 		}
 	}
 
+    toggleAppNamedDirectories = async  (appNamedDirectoriesEnabled: boolean) => {
+        if (!appNamedDirectoriesEnabled) {
+            await this.serverAPI.callPluginMethod('enable_app_named_directories', {});
+        } else {
+            await this.serverAPI.callPluginMethod('disable_app_named_directories', {});
+        }
+    }
+
 	updateMicGain = async (newMicGain: number) => {
 		await this.serverAPI.callPluginMethod('update_mic_gain', {new_gain: newMicGain});
 	}
@@ -159,6 +167,8 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 
 	const [micSourcesList, setMicSourcesList] = useState<DropdownOption[]>([{data: "NA", label: "Default Mic"}]);
 
+    const [appNamedDirectoriesEnabled, setAppNamedDirectoriesEnabled] = useState<boolean>(false);
+
 	// const audioBitrateOption128 = { data: "128", label: "128 Kbps" } as SingleDropdownOption
 	// const audioBitrateOption192 = { data: "192", label: "192 Kbps" } as SingleDropdownOption
 	// const audioBitrateOption256 = { data: "256", label: "256 Kbps" } as SingleDropdownOption
@@ -203,6 +213,9 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 		} else {
 			setMicSource({data: getMicSource.result as string, label: getMicSource.result})
 		}
+
+        const getAppNamedDirectoriesEnabled = await serverAPI.callPluginMethod('get_app_named_directories', {});
+        setAppNamedDirectoriesEnabled(getAppNamedDirectoriesEnabled.result as boolean);
 
 		// const getModeResponse = await serverAPI.callPluginMethod('get_current_mode', {});
 		// setMode(getModeResponse.result as string);
@@ -300,6 +313,10 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 		logic.toggleMicrophone(microphoneEnabled);
 	}
 
+    const appNamedDirectoriesToggled = async () => {
+        logic.toggleAppNamedDirectories(appNamedDirectoriesEnabled);
+    }
+
 	const changeMicGain = async () => {
 		logic.updateMicGain(micGain)
 	}
@@ -338,7 +355,18 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 					checked={isRolling}
 					onChange={(e) => { setRolling(e); rollingToggled(); }}
 				/>
-				<div>Steam + Start saves a 30 second clip in replay mode. If replay mode is off, this shortcut will enable it.</div>
+				<div><s>Steam + Start saves a 30 second clip in replay mode. If replay mode is off, this shortcut will enable it.</>></div>
+                <div>Shortcut is currently non-functional. Please record manually using the options below</div>
+
+                <PanelSectionRow>
+                    <ToggleField
+                        label="App Named Directories"
+                        disabled={isCapturing}
+                        checked={appNamedDirectoriesEnabled}
+                        onChange={(e) => { setAppNamedDirectoriesEnabled(e); appNamedDirectoriesToggled(); }}
+                    />
+                    <div>Save recordings to directories based on the name of the currently running application.</div>
+                </PanelSectionRow>
 				<ToggleField
 					label="Enable Microphone Recording"
 					checked={microphoneEnabled}


### PR DESCRIPTION
Provides an option for App Named Folders

When disabled, videos will save under the configured folder

Assuming a folder of `~/Videos`

Example Output: `~/Videos/CloverPit-30.0s-2025-10-27_20-13-31.mp4`

When enabled, the videos will instead be saved in an additional folder under that which is configured, matching the name of the running app (game)

Example Output: `~/Videos/CloverPit/CloverPit-30.0s-2025-10-27_20-13-31.mp4`
___

## Note
I did already include this feature with https://github.com/evanjs/decky-recorder-fork/releases/tag/release%2FSteamOS-3.7.15-pre.1 (https://github.com/evanjs/decky-recorder-fork/commit/84c789c759cefe06c1c9875861959a7b9d850790)

But I forgot to include the changes to make it an optional feature, just in case.